### PR TITLE
Added --halt-on-error in Makefile to prevent compiler hanging on error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 TARGET = main
+LUALATEXFLAGS = --halt-on-error
 
 all:
-	lualatex $(TARGET)
+	lualatex $(LUALATEXFLAGS) $(TARGET)
 
 clean:
 	-rm *.aux *.log *.nav *.out *.snm *.toc


### PR DESCRIPTION
In most situations, especially when compiling using custom tools e.g. vscode's Latex Workshop, it is more streamlined to have the compiler terminate on error rather than hang waiting for input.