### PR TITLE
Update ctu-paths.tex

### DIFF
--- a/ctu-paths.tex
+++ b/ctu-paths.tex
@@ -1,3 +1,3 @@
 
-\newcommand{\logopath}{./logo}
-\newcommand{\templatepath}{.}
+\providecommand{\logopath}{./logo}
+\providecommand{\templatepath}{.}


### PR DESCRIPTION
This solves the issue with multiple definitions of "logopath" and "templatepath".
Change:
\newcommand -> \providecommand